### PR TITLE
Use a more friendly error message for lines skipped

### DIFF
--- a/main.go
+++ b/main.go
@@ -263,6 +263,10 @@ func main() {
 		if err == ErrLogEOF {
 			return
 		}
+		if err == ErrInvalidLogLine {
+			fmt.Println("Skipping log line:", err)
+			continue
+		}
 		if err != nil {
 			fmt.Println("Error parsing postgres log:", err)
 			continue


### PR DESCRIPTION
This will output the following:

```
Skipping log line: The parser could not derive query or plan info from the log line
```

@BenjaminCall 