### PR TITLE
TCPLogger Retries

### DIFF
--- a/tcp_logger.go
+++ b/tcp_logger.go
@@ -64,6 +64,7 @@ func (t *TCPLogger) Start() {
 }
 
 func (t *TCPLogger) handleConnError(err error, b []byte) {
+	log.Println("Error while writing to TCPLogger.conn:", err.Error())
 	if err == os.ErrDeadlineExceeded || err == io.EOF {
 		t.RetryConnection()
 	}
@@ -75,14 +76,17 @@ func (t *TCPLogger) handleConnError(err error, b []byte) {
 		log.Println("Retry limit met on TCPLogger.. sleeping for a minute before continuing.")
 		t.logLines <- b
 		time.Sleep(t.sleepDuration)
+		t.RetryConnection()
 		t.retries = 0
 	}
 }
 
 // RetryConnection will attempt to reestablish connection to net.Conn
 func (t *TCPLogger) RetryConnection() error {
+	log.Println("Attempting tcp connection reestablish...")
 	conn, err := net.Dial(t.conn.RemoteAddr().Network(), t.conn.RemoteAddr().String())
 	if err != nil {
+		log.Println("Error reconnecting:", err)
 		return err
 	}
 	t.swapConn(conn)


### PR DESCRIPTION
* retry connection if tcp logger slept due to retry limit being met
* log error during dial on TCPLogger.RetryConnection()

Currently, at process start, the tcp connection is writeable.  Something happens after extended run time and the message is getting a silent error during `Write()`.  We should log any `Dial` errors.

It seems reasonable to me to retry connection after a tcp logger sleep due to retry limit being hit as well, as the current error checks for `RetryConnection` are limited and clearly missing whatever error is being returned during `Write()` currently.